### PR TITLE
Fix for issue #1, but possibly not in the best way.

### DIFF
--- a/src/py/env.py
+++ b/src/py/env.py
@@ -94,7 +94,7 @@ class Environment:
 
     def __repr__( self):
         ret = "\nEnvironment %s:\n" % self.level
-        keys = self.binds.keys()
+        keys = [i for i in self.binds.keys() if not i[:2] == "__"]
 
         for key in keys:
             ret = ret + " %5s: %s\n" % (key, self.binds[key])


### PR DESCRIPTION
The environment data structure had a reference to itself called
**global**, which it attempted to print, which resulted in infinite
recursion.
