### PR TITLE
I think the plus function that was in core.lisp was wrong, and this fixes it.

### DIFF
--- a/src/core.lisp
+++ b/src/core.lisp
@@ -129,4 +129,4 @@
 
 (label zero (lambda (s z) z))
 (label one (lambda (s z) (s z)))
-(label plus (lambda (w z) (lambda (y x) (z y x))))
+(label plus (lambda (m n) (lambda (f x) (m f (n f x)))))


### PR DESCRIPTION
Testing that the plus function was incorrect was accomplished as such:

(label z (quote (z)))
(label succ (lambda (x) (cons (quote s) x)))
((plus one one) succ z)

The result expected was (s s z), however the interpreter crashed.
